### PR TITLE
Move to MySQL

### DIFF
--- a/connectors/MySqlClient.py
+++ b/connectors/MySqlClient.py
@@ -102,3 +102,6 @@ class MySqlClient(DbConnector):
         cursor.execute(query, (count, comments_url))
         cursor.close()
         self.conn.commit()
+
+    def record_error(self, url, code, headers, body):
+        pass

--- a/utility/client_factory.py
+++ b/utility/client_factory.py
@@ -1,5 +1,5 @@
 from connectors.MySqlClient import MySqlClient
-import constants
+import utility.constants
 
 def get_db_client():
     return MySqlClient(host=constants.DB_HOST,user=constants.DB_USER,password=constants.DB_PASS,db_name=constants.DB_NAME)

--- a/utility/client_factory.py
+++ b/utility/client_factory.py
@@ -1,5 +1,5 @@
-from connectors.dynamo.DynamoDbClient import DynamoDbClient
-
+from connectors.MySqlClient import MySqlClient
+import constants
 
 def get_db_client():
-    return DynamoDbClient()
+    return MySqlClient(host=constants.DB_HOST,user=constants.DB_USER,password=constants.DB_PASS,db_name=constants.DB_NAME)

--- a/utility/constants.py
+++ b/utility/constants.py
@@ -5,10 +5,10 @@ import os
 NB_ENDPOINT = 'https://newsblur.com'
 NB_HN_FEED_ID = 5982259
 #DATABASE_FILENAME = 'stories.sqlite'
-DB_HOST = os.getenv('DB_HOST','stage.benmordue.co.uk')
+DB_HOST = os.getenv('DB_HOST','93.170.105.134')
 # DB_PORT = 5432
-DB_USER = os.getenv('DB_USER','No username')
-DB_PASS = os.getenv('DB_PASS','No password')
+DB_USER = os.getenv('DB_USER','nbuser')
+DB_PASS = os.getenv('DB_PASS','nbpass')
 DB_NAME = 'nb_stories'
 MAX_PARSE = 9000 # max number of Newsblur starred stories to process
 BATCH_SIZE = 10 # how many batches to parse and enter in DB in one go


### PR DESCRIPTION
Moving (back) to MySQL as the data store.
Dynamodb isn't a great fit. Originally chosen for convenience, and because I thought the cost would be low. Problems:
- table scan is expensive
- overall cost is slightly more than anticipated
- relational features could actually be useful